### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/TrustedAuthority/ta_registration.py
+++ b/TrustedAuthority/ta_registration.py
@@ -13,7 +13,7 @@ curve = registry.get_curve('brainpoolP256r1') # 256-bit
 
 
 ta_public_key, ta_private_key = "H" , "H"
-TA_REG_SERVER_ADD = '0.0.0.0'
+TA_REG_SERVER_ADD = '127.0.0.1'  # Bind to localhost for security
 TA_REG_SERVER_PORT = 4444
 
 def save_rsu_data(SID, Chall, PubKey):


### PR DESCRIPTION
Potential fix for [https://github.com/Ujjwal0919/V2XSecurityProtocol/security/code-scanning/4](https://github.com/Ujjwal0919/V2XSecurityProtocol/security/code-scanning/4)

To fix the issue, the server should bind to a specific interface instead of all interfaces. This can be achieved by replacing the value of `TA_REG_SERVER_ADD` with the IP address of the dedicated interface that the server should listen on. For example, if the server should only accept connections from the local machine, `127.0.0.1` can be used. Alternatively, if the server should listen on a specific network interface, the corresponding IP address of that interface should be used.

The changes involve:
1. Updating the value of `TA_REG_SERVER_ADD` to a specific IP address.
2. Ensuring that the server's functionality remains unchanged while improving its security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
